### PR TITLE
Ignore failed `docker rmi` commands when cleaning up

### DIFF
--- a/bashbrew/bashbrew.sh
+++ b/bashbrew/bashbrew.sh
@@ -144,8 +144,13 @@ remove_image() {
 	while [ "$retries" -lt 3 ]; do
 		let retries=retries+1
 		echo "Retrying remove $1"
-		if "$docker" rmi -f "$1" ;then
-			break	
+		if ! (
+			set -x
+			"$docker" rmi -f "$1"
+			break
+		); then
+			# Just continue when  `docker rmi` failed
+			continue
 		fi
 	done
 }


### PR DESCRIPTION
So that the build will not be marked as failed if it fails to clean up an image (which can be used by another build at the same time so it cannot be removed)

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>