### PR TITLE
Remove double quotes around platform parameter

### DIFF
--- a/bashbrew/bashbrew.sh
+++ b/bashbrew/bashbrew.sh
@@ -467,7 +467,7 @@ while [ "$#" -gt 0 ]; do
 				if ! (
 					set -x
 					"$docker" pull "balenalib/$repoTag"
-					"$docker" build --pull "$platform" -t "$repoTag" "$gitRepo/$gitDir"
+					"$docker" build --pull $platform -t "$repoTag" "$gitRepo/$gitDir"
 				) &>> "$thisLog"; then
 					echo "- failed 'docker build'; see $thisLog"
 					didFail=1


### PR DESCRIPTION
With the double quotes, `docker build` will see empty string as parameter if platform is empty but we just want `docker build` to ignore it in that case.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>